### PR TITLE
Add option to tail oplog and get per ns/api counts

### DIFF
--- a/collector/mongodb_collector.go
+++ b/collector/mongodb_collector.go
@@ -31,6 +31,7 @@ type MongodbCollectorOpts struct {
 	TLSHostnameValidation    bool
 	CollectReplSet           bool
 	CollectOplog             bool
+	TailOplog                bool
 	CollectTopMetrics        bool
 	CollectDatabaseMetrics   bool
 	CollectCollectionMetrics bool
@@ -98,6 +99,11 @@ func (exporter *MongodbCollector) Collect(ch chan<- prometheus.Metric) {
 		if exporter.Opts.CollectOplog {
 			glog.Info("Collecting Oplog Status")
 			exporter.collectOplogStatus(mongoSess, ch)
+		}
+
+		if exporter.Opts.TailOplog {
+			glog.Info("Collecting Oplog Tail Stats")
+			exporter.collectOplogTailStats(mongoSess, ch)
 		}
 
 		if exporter.Opts.CollectTopMetrics {
@@ -171,6 +177,17 @@ func (exporter *MongodbCollector) collectOplogStatus(session *mgo.Session, ch ch
 	}
 
 	return oplogStatus
+}
+
+func (exporter *MongodbCollector) collectOplogTailStats(session *mgo.Session, ch chan<- prometheus.Metric) *OplogTailStats {
+	oplogTailStats := GetOplogTailStats(session)
+
+	if oplogTailStats != nil {
+		glog.Info("exporting oplogTailStats Metrics")
+		oplogTailStats.Export(ch)
+	}
+
+	return oplogTailStats
 }
 
 func (exporter *MongodbCollector) collectTopStatus(session *mgo.Session, ch chan<- prometheus.Metric) *TopStatus {

--- a/collector/oplog_tail.go
+++ b/collector/oplog_tail.go
@@ -1,0 +1,71 @@
+package collector
+
+import (
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rwynn/gtm"
+	"gopkg.in/mgo.v2"
+)
+
+var (
+	oplogEntryCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Subsystem: "oplogtail",
+		Name:      "entry_count",
+		Help:      "The total number of entries observed in the oplog by ns/op",
+	}, []string{"ns", "op"})
+	oplogTailError = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Subsystem: "oplogtail",
+		Name:      "tail_error",
+		Help:      "The total number of errors while tailing the oplog",
+	})
+)
+
+var tailer *OplogTailStats
+
+type OplogTailStats struct{}
+
+func (o *OplogTailStats) Start(session *mgo.Session) {
+	defer session.Close()
+	session.SetMode(mgo.Monotonic, true)
+
+	ctx := gtm.Start(session, nil)
+
+	// ctx.OpC is a channel to read ops from
+	// ctx.ErrC is a channel to read errors from
+	// ctx.Stop() stops all go routines started by gtm.Start
+	for {
+		// loop forever receiving events
+		select {
+		case err := <-ctx.ErrC:
+			// handle errors
+			fmt.Println(err)
+		case op := <-ctx.OpC:
+			oplogEntryCount.WithLabelValues(op.Namespace, op.Operation).Add(1)
+		}
+	}
+}
+
+// Export exports metrics to Prometheus
+func (status *OplogTailStats) Export(ch chan<- prometheus.Metric) {
+	oplogEntryCount.Collect(ch)
+	oplogTailError.Collect(ch)
+}
+
+// Describe describes metrics collected
+func (status *OplogTailStats) Describe(ch chan<- *prometheus.Desc) {
+	oplogEntryCount.Describe(ch)
+	oplogTailError.Describe(ch)
+}
+
+func GetOplogTailStats(session *mgo.Session) *OplogTailStats {
+	if tailer == nil {
+		tailer = &OplogTailStats{}
+		// Start a tailer with a copy of the session (to avoid messing with the other metrics in the session)
+		tailer.Start(session.Copy())
+	}
+
+	return tailer
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,41 +1,56 @@
-hash: 7dc238d7118210ebe55b508ed1d11af8c39132025807b9cddc2ec2489d9926f6
-updated: 2016-11-23T09:05:11.556107146-08:00
+hash: 039dc285fae0ee4b97a236ec9935fff74f31b66c011fef0fdf64ab746d07a02a
+updated: 2018-03-15T15:08:18.90732609-07:00
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
   subpackages:
   - quantile
+- name: github.com/globalsign/mgo
+  version: baa28fcb8e7d5dfab92026c0920cb6c9ae72faa2
+  subpackages:
+  - bson
+  - internal/json
+  - internal/sasl
+  - internal/scram
 - name: github.com/golang/glog
   version: 23def4e6c14b4da8ac2ed8007337bc5eb5007998
 - name: github.com/golang/protobuf
-  version: 8ee79997227bf9b34611aee7946ae64735e6fd93
+  version: 17ce1425424ab154092bbb43af630bd647f3bb0d
   subpackages:
   - proto
 - name: github.com/matttproud/golang_protobuf_extensions
   version: c12348ce28de40eed0136aa2b644d0ee0650e56c
   subpackages:
   - pbutil
+- name: github.com/pkg/errors
+  version: 645ef00459ed84a119197bfb8d8205042c6df63d
 - name: github.com/prometheus/client_golang
   version: c5b7fccd204277076155f10851dad72b76a49317
   subpackages:
   - prometheus
 - name: github.com/prometheus/client_model
-  version: fa8ad6fec33561be4280a8f0514318c79d7f6cb6
+  version: 6f3806018612930941127f2a7c6c453ba2c527d2
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 0d5de9d6d8629cb8bee6d4674da4127cd8b615a3
+  version: e3fb1a1acd7605367a2b378bc2e2f893c05174b7
   subpackages:
   - expfmt
-  - model
   - internal/bitbucket.org/ww/goautoneg
+  - model
 - name: github.com/prometheus/procfs
-  version: abf152e5f3e97f2fafac028d2cc06c1feb87ffa5
+  version: a6e9df898b1336106c743392c48ee0b71f5c4efa
+  subpackages:
+  - xfs
+- name: github.com/rwynn/gtm
+  version: c5642730dfa1ae9ceaebf33baa28d19a24bb0714
+- name: github.com/serialx/hashring
+  version: 6a9381c5a83e926b9f1fd907395a581e69747e96
 - name: gopkg.in/mgo.v2
   version: 3f83fa5005286a7fe593b055f0d7771a7dce4655
   subpackages:
   - bson
+  - internal/json
   - internal/sasl
   - internal/scram
-  - internal/json
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -8,3 +8,5 @@ import:
 - package: gopkg.in/mgo.v2
   subpackages:
   - bson
+- package: github.com/rwynn/gtm
+  version: c5642730dfa1ae9ceaebf33baa28d19a24bb0714

--- a/mongodb_exporter.go
+++ b/mongodb_exporter.go
@@ -50,6 +50,7 @@ var (
 	mongodbUserName                     = flag.String("mongodb.username", "", "Username to connect to Mongodb")
 	mongodbAuthMechanism                = flag.String("mongodb.mechanism", "", "auth mechanism to connect to Mongodb (ie: MONGODB-X509)")
 	mongodbCollectOplog                 = flag.Bool("mongodb.collect.oplog", true, "collect Mongodb Oplog status")
+	mongodbCollectOplogTail             = flag.Bool("mongodb.collect.oplog_tail", false, "tail Mongodb Oplog to get stats")
 	mongodbCollectReplSet               = flag.Bool("mongodb.collect.replset", true, "collect Mongodb replica set status")
 	mongodbCollectTopMetrics            = flag.Bool("mongodb.collect.top", false, "collect Mongodb Top metrics")
 	mongodbCollectDatabaseMetrics       = flag.Bool("mongodb.collect.database", false, "collect MongoDB database metrics")
@@ -153,6 +154,7 @@ func registerCollector() {
 		TLSCaFile:                *mongodbTLSCa,
 		TLSHostnameValidation:    !(*mongodbTLSDisableHostnameValidation),
 		CollectOplog:             *mongodbCollectOplog,
+		TailOplog:                *mongodbCollectOplogTail,
 		CollectReplSet:           *mongodbCollectReplSet,
 		CollectTopMetrics:        *mongodbCollectTopMetrics,
 		CollectDatabaseMetrics:   *mongodbCollectDatabaseMetrics,


### PR DESCRIPTION
Mongo's internal metrics are only API level (insert/update/delete). This
adds the ability to split those out by ns as well.